### PR TITLE
fix: User role filtering to exclude role 9 in Admin Dashboard

### DIFF
--- a/ASI.Basecode.WebApp/Controllers/AdminDashboard.cs
+++ b/ASI.Basecode.WebApp/Controllers/AdminDashboard.cs
@@ -44,7 +44,7 @@ namespace ASI.Basecode.WebApp.Controllers
             try
             {
                 _logger.LogInformation("Start retrieving all users for Admin User Dashboard.");
-                var data = _userService.RetrieveAll().ToList();
+                var data = _userService.RetrieveAll().Where(data => data.Role != 9).ToList();
                 ViewData["Role"] = UserRole;
 
                 var model = new UserPageViewModel


### PR DESCRIPTION
- Updated the controller to filter out users with role 9 by using `data.Role != 9` instead of the non-existent `UserRole` property.
- Ensured that users with a role of 9 are excluded from the `RetrieveAll()` result.